### PR TITLE
Created an alternate implmeneation of the DVIGFX8 class

### DIFF
--- a/examples/DVI8DisplayResolutionTest/DVI8DisplayResolutionTest.ino
+++ b/examples/DVI8DisplayResolutionTest/DVI8DisplayResolutionTest.ino
@@ -1,0 +1,95 @@
+// Display a basic info screen to test the different PicoDVI8 resolutions
+//
+#include <PicoDVI8.h>
+
+// Create an non-interlaced 320x240 instance
+PicoDVI8 tft = PicoDVI8(320, 480, dvi_timing_640x480p_60hz, VREG_VOLTAGE_1_10, pimoroni_demo_hdmi_cfg, 2);
+// Create an interlaced 320x480 instance
+//PicoDVI8 tft = PicoDVI8(320, 480, dvi_timing_640x480p_60hz, VREG_VOLTAGE_1_10, pimoroni_demo_hdmi_cfg, 1);
+// Create an non-interlaced 400x240 instance
+//PicoDVI8 tft = PicoDVI8(400, 480, dvi_timing_800x480p_60hz, VREG_VOLTAGE_1_25, pimoroni_demo_hdmi_cfg, 2);
+// Create an interlaced 400x480 instance
+//PicoDVI8 tft = PicoDVI8(400, 480, dvi_timing_800x480p_60hz, VREG_VOLTAGE_1_25, pimoroni_demo_hdmi_cfg, 1);
+
+void centerText(Adafruit_GFX &tft,const char *str, int y) {
+  int16_t  x1, y1;
+  uint16_t w, h;
+
+  tft.getTextBounds(str, 0, 0, &x1, &y1, &w, &h);
+
+  tft.setCursor((tft.width() - w) / 2, y);
+  tft.print(str);
+}
+
+//
+// Display the screen resolution, heap info and cpu clock frequency
+//
+void displayInfo(Adafruit_GFX &tft) {
+  
+  int y = 2;
+
+  tft.setRotation(0);     //Portrait
+  tft.fillScreen(PicoDVI8::BLACK);
+  tft.setTextColor(PicoDVI8::WHITE, PicoDVI8::BLACK);
+  tft.setTextSize(2);     // System font is 8 pixels.  ht = 8*2=16
+  tft.setCursor(0, 0);
+
+  tft.setRotation(0);
+
+  tft.drawRect(10, 10, tft.width() - 20, tft.height() - 20, PicoDVI8::WHITE);
+  tft.setTextSize(2);
+  centerText(tft,"PicoDVI8 Display", y * 16);
+  y += 2;
+  tft.setTextSize(1);
+  tft.setCursor(30, y++ * 16);
+  tft.print("Width: ");
+  tft.print(tft.width());
+  tft.setCursor(30, y++ * 16);
+  tft.print("Height: ");
+  tft.print(tft.height());
+  tft.setCursor(30, y++ * 16);
+  tft.print("Total Heap:");
+  tft.print(rp2040.getTotalHeap());
+  tft.setCursor(30, y++ * 16);
+  tft.print("Free Heap:");
+  tft.print(rp2040.getFreeHeap());
+  tft.setCursor(30, y++ * 16);
+
+  uint f_clk_sys = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_CLK_SYS);
+  tft.print("CLK sys:");
+  tft.print(f_clk_sys);
+  tft.print("khz");
+  tft.fillRect(30,y++*16,tft.width()-60,16,PicoDVI8::RED);
+  tft.fillRect(30,y++*16,tft.width()-60,16,PicoDVI8::BLUE);
+  tft.fillRect(30,y++*16,tft.width()-60,16,PicoDVI8::GREEN);
+}
+
+void setup()
+{
+  int count = 0;
+
+  Serial.begin(115200);
+ 
+  // wait for up to 4 seconds
+  while ((!Serial) && (count < 40)) {
+    // wait for serial port to connect. Needed for native USB port only
+    count++;
+    delay(100);
+  }
+  
+  Serial.println("Starting");
+
+  if (tft.begin()) {
+    displayInfo(tft);
+
+  } else {
+    Serial.println("Display failed to start");
+  }
+
+}
+
+
+void loop()
+{
+
+}

--- a/src/PicoDVI.cpp
+++ b/src/PicoDVI.cpp
@@ -4,8 +4,8 @@
 // PicoDVI class encapsulates some of the libdvi functionality -------------
 // Subclasses then implement specific display types.
 
-static PicoDVI *dviptr = NULL; // For C access to active C++ object
-static volatile bool wait_begin = true;
+PicoDVI *dviptr = NULL; // For C access to active C++ object
+volatile bool wait_begin = true;
 
 // Runs on core 1 on startup
 void setup1(void) {

--- a/src/PicoDVI8.cpp
+++ b/src/PicoDVI8.cpp
@@ -1,0 +1,290 @@
+#include "PicoDVI8.h"
+#include "libdvi/tmds_encode.h"
+
+//
+// Needed access to be called from setup1() on core1
+// 
+extern PicoDVI *dviptr;
+extern volatile bool wait_begin;
+
+#ifndef MIN
+#define MIN(a,b)    (((a) < (b)) ? a : b)
+#endif
+
+//
+// Include the tmds values to build our color palette
+//
+const uint32_t tmds_table[] = {
+#include "libdvi/tmds_table.h"
+};
+
+PicoDVI8 * PicoDVI8::instance = NULL;
+
+PicoDVI8::PicoDVI8(const uint16_t w, const uint16_t h,
+          const struct dvi_timing &t,
+          vreg_voltage v,
+          const struct dvi_serialiser_cfg &c,
+          uint8_t repeate) :
+       PicoDVI(t, v, c), 
+       GFXcanvas8(MIN(w,t.h_active_pixels / DVI_SYMBOLS_PER_WORD), 
+                  MIN(h,t.v_active_lines / repeate)) {
+
+   int linePixelCount = t.h_active_pixels / DVI_SYMBOLS_PER_WORD;
+
+   instance = this;
+   exitMainLoop = false;
+   
+   dvi_vertical_repeat = repeate;
+   dvi_monochrome_tmds = false;
+
+   if (repeate == 1) {
+       interlace = true;
+   } else {
+       interlace = false;
+   }
+
+
+   blankLine = (uint32_t *)malloc(3 * linePixelCount * sizeof(uint32_t));
+
+   uint32_t * p = blankLine;
+
+   // index 0 is black
+   for (int i = 0; i < 3*linePixelCount; i++) {
+      *p++ = tmds_table[0];
+   }
+
+   resetPalette();
+}
+
+PicoDVI8:: ~PicoDVI8(void) {
+
+  instance = NULL;
+
+  if (blankLine) {
+      free(blankLine);
+  }
+  blankLine = NULL;
+
+  exitMainLoop = false;
+
+  // give it some time to exit 
+  delay(10);
+
+  // reset core 1 wait flag for the PicoDVI baseclass
+  wait_begin = true; 
+
+  rp2040.restartCore1();
+
+} 
+
+void __not_in_flash_func(PicoDVI8::scanBufferMain)(struct dvi_inst *inst) {
+
+  uint pixwidth = inst->timing->h_active_pixels;
+  uint words_per_channel = pixwidth / DVI_SYMBOLS_PER_WORD;
+
+  uint screenScanLines = inst->timing->v_active_lines / dvi_vertical_repeat;
+  uint screenWidth = inst->timing->h_active_pixels / DVI_SYMBOLS_PER_WORD;
+
+  uint16_t scanline = 0;
+  uint8_t  even = true;
+
+  while (!exitMainLoop) {
+
+    uint32_t *tmdsbuf;
+    uint8_t *b8;
+
+    queue_remove_blocking_u32(&inst->q_tmds_free, &tmdsbuf);
+
+    // discard our blankline buffer
+    if (tmdsbuf == blankLine) {
+        tmdsbuf = NULL;
+    }
+
+    if (tmdsbuf) {
+
+      uint32_t * pB = tmdsbuf;
+      uint32_t * pG = tmdsbuf + words_per_channel;
+      uint32_t * pR = tmdsbuf + 2 * words_per_channel;
+  
+      if (scanline < HEIGHT) {
+            
+        b8  = &getBuffer()[WIDTH * scanline]; // New scanline
+
+        for (int i = 0; i < WIDTH; i++) {
+             uint8_t  idx = b8[i];
+       
+             *pB++ = btmds[idx];
+             *pG++ = gtmds[idx];
+             *pR++ = rtmds[idx];
+         }
+     
+         // index 0 is black
+         for (int i = WIDTH; i < screenWidth; i++) {
+             *pB++ = tmds_table[0];
+             *pG++ = tmds_table[0];
+             *pR++ = tmds_table[0];
+         }
+      } else {
+
+         // re-queue the free buffer and use our blank line instead
+         queue_add_blocking_u32(&inst->q_tmds_free, &tmdsbuf);
+
+         tmdsbuf = blankLine;
+      }
+   
+      queue_add_blocking_u32(&inst->q_tmds_valid, &tmdsbuf);
+
+      //
+      // If interlacing, add blank lines every other line.
+      // So 1/2 the lines are generated each frame.
+      //
+      if (interlace) {
+
+          //
+          // scanline % 2 produces 0 for even values and 1 for odd,
+          // so invert it to convert it to a bool
+          //
+          if ((!(scanline % 2) == even)) {
+
+              // don't add a blank line after the last odd scanline
+              if (scanline+1 != screenScanLines) {
+                 queue_add_blocking_u32(&inst->q_tmds_valid, &blankLine);
+                 scanline = (scanline + 1) % screenScanLines;     
+              }
+          }
+
+          //
+          //  last even line is 478, scanline == 479 after injection
+          //  so queue line zero as blank and switch to odd.
+          //
+          if ((even) && ((scanline + 1) == screenScanLines)) {
+              queue_add_blocking_u32(&inst->q_tmds_valid, &blankLine);
+              scanline = (scanline + 1) % screenScanLines;     
+              even = false;
+          } else 
+          // last odd scanline is 479, since we skipped injection
+          if ((!even) && (scanline+1 == screenScanLines)) {
+              even = true;
+          }
+      }
+
+      scanline = (scanline + 1) % screenScanLines;     // Next scanline index
+    }
+  }
+}
+
+bool PicoDVI8::begin(void) {
+
+  dviptr = this;
+
+  resetPalette();
+
+  mainloop = _scanBufferMain; 
+  dvi0.scanline_callback = NULL;
+
+  PicoDVI::begin();
+
+  wait_begin = false; // Set core 1 in motion
+
+  return true;
+}
+
+void     PicoDVI8::resetPalette() {
+ 
+   paletteIdx = 0; 
+   addColor(BLACK);
+   addColor(NAVY);
+   addColor(DARK_GREEN);
+   addColor(DARK_CYAN);
+   addColor(MAROON);
+   addColor(PURPLE);
+   addColor(OLIVE);
+   addColor(LIGHT_GREY);
+   addColor(DARK_GREY);
+   addColor(BLUE); 
+   addColor(GREEN);
+   addColor(CYAN);
+   addColor(RED);
+   addColor(MAGENTA);
+   addColor(YELLOW);
+   addColor(WHITE);
+
+   for (int i = paletteIdx; i < PICODVI8_MAX_COLORS; i++) {
+      setTMDS(i,0x0000);
+      palette[i] = 0x0000;
+   }
+}
+
+uint8_t  PicoDVI8::getColorIdx(uint16_t color) {
+
+   for (int i = 0; i < paletteIdx; i++) {
+     if (palette[i] == color) {
+         return (i);
+     }
+   }
+   return (addColor(color));
+}
+
+void PicoDVI8::setTMDS(uint8_t idx,uint16_t color) {
+
+  rtmds[idx] = tmds_table[(color & 0b1111100000000000) >> 10] ;
+  gtmds[idx] = tmds_table[(color & 0b0000011111100000) >>  5] ;
+  btmds[idx] = tmds_table[(color & 0b0000000000011111) <<  1] ;
+
+}
+
+uint8_t  PicoDVI8::addColor(uint16_t color) {
+
+    if (paletteIdx < (PICODVI8_MAX_COLORS-1)) {
+        setTMDS(paletteIdx,color);
+        palette[paletteIdx] = color;
+        return (paletteIdx++);
+    }
+
+    //
+    // Look for a similar color by masking
+    // out the lower color bits.
+    //
+    uint32_t mask = 0b0000100001100001;
+    for (int j = 0; j < 3; j++) {
+       uint16_t workingMask = ~mask;
+       uint16_t maskColor = color & workingMask;
+
+       for (int i = 0; i < paletteIdx; i++) {
+         if ((palette[i] & workingMask) == maskColor) {
+             return (i);
+         }
+       }
+       mask = (mask << 1) | 0b0000100001100001;
+    }
+
+    //  If no matches were found, reuse the last spot 
+    Serial.println("Ran out of palette entries");
+
+    setTMDS(paletteIdx,color);
+    palette[paletteIdx] = color;
+
+    return (paletteIdx);
+}
+
+
+void PicoDVI8::drawPixel(int16_t x, int16_t y, uint16_t color) {
+    
+   GFXcanvas8::drawPixel(x,y,getColorIdx(color));
+}
+
+void PicoDVI8::fillScreen(uint16_t color) {
+   resetPalette();
+   GFXcanvas8::fillScreen(getColorIdx(color));
+}
+
+void PicoDVI8::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) {
+   GFXcanvas8::drawFastVLine(x,y,h,getColorIdx(color));
+}
+
+void PicoDVI8::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) {
+   GFXcanvas8::drawFastHLine(x,y,w,getColorIdx(color));
+}
+
+
+

--- a/src/PicoDVI8.h
+++ b/src/PicoDVI8.h
@@ -1,0 +1,131 @@
+#ifndef PICO_DVI_8_H
+#define PICO_DVI_8_H
+
+#include "PicoDVI.h"
+
+#define PICODVI8_MAX_COLORS   256
+
+//
+// PicoDVI8 is a framebuffer that automatically builds the color palette 
+// based on the colors in the calls to the GFXcanvas8.   Only 
+// one instance of this class should be create at one one time, 
+// since the scanBufferMain runs continuiosly on core1.  The color palette 
+// will be reset when the fillScreen method is called.
+//
+// The frame buffer width/height can be set to 1/2 the monitor timing.
+// So for 640x480, the max w is 320 and the max h is 240.  You can also
+// set the w or h lower than 1/2 and it will pad out the right/bottom 
+// with black lines. 
+//
+// If you want to use the full vertical resolution, you can set repeate to
+// 1.   This will then use an interlaced scan line model (see comments 
+// below for scanBufferMain for more info).  This works fine for lcd monitors,
+// but did not look good on usb capture dongles.
+//
+class PicoDVI8 : public PicoDVI, public GFXcanvas8 {
+public:
+  PicoDVI8(const uint16_t w = 320, const uint16_t h = 240,
+          const struct dvi_timing &t = dvi_timing_640x480p_60hz,
+          vreg_voltage v = VREG_VOLTAGE_1_10,
+          const struct dvi_serialiser_cfg &c = pimoroni_demo_hdmi_cfg,
+          uint8_t repeate = 2);
+  ~PicoDVI8(void);
+
+  bool begin(void);
+
+  static PicoDVI8 * getInstance() { return instance; }; 
+
+  //
+  // Generate the scanlines from the GFXcanvas8 framebuffer
+  // This happens on the second core.  This is done a bit
+  // differently for performance reasons.   
+  //
+  // The pixel clock is run at 10 clock cycles per pixes.
+  // So for 640x480 the system clock is set to 252mhz, which
+  // gives 8750 clock cycles (252,000,000 / 480 / 60 fps) to
+  // generate the scan line.   The default method in 
+  // dvi_scanbuf_main_16bpp takes about 28,000 clock cycles to 
+  // convert the scanline to tmds.  So it can barley keep up with
+  // generating every other scan line (hence the red lines
+  // displaying randomly).
+  //
+  // So this version of the scanBufferMain, converts the 
+  // color palette entries into the tmds 10 bit values 
+  // and builds the scan line buffer directly.   This takes about
+  // 16000 clock cycles, so you can do 240 scan lines per second
+  // with no red lines.
+  //
+  // One of the reason to use a color pallet was to save ram, but
+  // it would be nice to be able to be able to get a full 480 scan 
+  // lines.   To acheve this, it uses an interlacing pattern.  So for 
+  // one frame only the even scan lines are generated and a black line
+  // is sent for the odd scan lines.   Then the next frame the odd scan
+  // lines are sent with blak even lines.   This works find on LCD monitors
+  // and looks like the old interlaced monitors (not as bright or crisp as
+  // non-interlaced).  This doesn't seem to work for usb capture dongles 
+  // (just looks like garbage on mine).  So try it, and if it works for you 
+  // great.   If not, use the double scan line (1/2 resolution) mode.
+  //
+  static void _scanBufferMain(struct dvi_inst *inst) {
+     instance->scanBufferMain(inst);
+  }
+  void scanBufferMain(struct dvi_inst *inst);
+
+  //
+  // GFX functions to build the pallete
+  //
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void fillScreen(uint16_t color);
+  void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
+  void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+
+  //
+  // Pallet functions.   They should not need to be called as they are automatically
+  // called as you use the framebuffer from the GFX functions above.   But if
+  // you want to set a specifc pallet, you canuse them to do that.
+  //
+  void     resetPalette();
+  uint8_t  addColor(uint16_t color);
+
+  // The default colors in the pallete
+  static const uint32_t BLACK      = (0x0000); 
+  static const uint32_t NAVY       = (0x000F); 
+  static const uint32_t DARK_GREEN = (0x03E0);
+  static const uint32_t DARK_CYAN  = (0x03EF); 
+  static const uint32_t MAROON     = (0x7800); 
+  static const uint32_t PURPLE     = (0x780F); 
+  static const uint32_t OLIVE      = (0x7BE0); 
+  static const uint32_t LIGHT_GREY = (0xC618); 
+  static const uint32_t DARK_GREY  = (0x7BEF); 
+  static const uint32_t BLUE       = (0x001F); 
+  static const uint32_t GREEN      = (0x07E0); 
+  static const uint32_t CYAN       = (0x07FF); 
+  static const uint32_t RED        = (0xF800); 
+  static const uint32_t MAGENTA    = (0xF81F); 
+  static const uint32_t YELLOW     = (0xFFE0); 
+  static const uint32_t WHITE      = (0xFFFF); 
+
+
+protected:
+
+  uint16_t palette[PICODVI8_MAX_COLORS];
+
+  void     setTMDS(uint8_t idx,uint16_t color);
+  uint32_t rtmds[PICODVI8_MAX_COLORS];
+  uint32_t gtmds[PICODVI8_MAX_COLORS];
+  uint32_t btmds[PICODVI8_MAX_COLORS];
+
+  uint8_t  getColorIdx(uint16_t color);
+
+  uint16_t paletteIdx;   // index of last used color
+ 
+  uint8_t  interlace;
+  uint32_t *blankLine;
+
+  uint8_t  exitMainLoop;
+
+  static PicoDVI8 *instance;
+};
+
+
+#endif


### PR DESCRIPTION
I barely got the DVIGFX8 class working in my env.   I was getting a lot of red lines when I could get it to work at all.   I dove into the code and realized that it was just taking too many cycles to generate the tmds scan lines.   So I implemented a TMDS palette and wrote a new main loop that was faster than the dvi_scanbuf_main_16bpp loop.   Give it a look/try and see if it is worth including.   I also implemented an interlaced mode to get the full 480 scan lines generated...   It looks like monitors from the 80/90s on an LCD, but doesn't work on usb hmdi capture dongles.

Thanks,

Toby