### PR TITLE
DVItext1: Add rudimentary terminal code handling

### DIFF
--- a/examples/1bit_text/1bit_text.ino
+++ b/examples/1bit_text/1bit_text.ino
@@ -23,9 +23,22 @@ void setup() { // Runs once on startup
     pinMode(LED_BUILTIN, OUTPUT);
     for (;;) digitalWrite(LED_BUILTIN, (millis() / 500) & 1);
   }
+  display.println("Type characters on serial to echo them!");
 }
 
+bool typewriter = false;
 void loop() {
-  display.print("Hello World!  ");
-  delay(50);
+  if (typewriter) {
+    while(Serial.available()) {
+      display.write(Serial.read());
+    }
+  } else {
+    if (Serial.available()) {
+        typewriter = true;
+      display.println("Entering typewriter mode.");
+    } else {
+      display.print("Hello World!  ");
+      delay(50);
+    }
+  }
 }

--- a/src/PicoDVI.h
+++ b/src/PicoDVI.h
@@ -339,5 +339,23 @@ public:
   */
   void _mainloop(void);
 
+  enum vt_action {
+    PRINTABLE,
+    NO_OUTPUT,
+    BELL,
+    CLEAR_EOL,
+    CLEAR_SCREEN,
+    CURSOR_LEFT,
+    CURSOR_POSITION,
+    CHAR_ATTR
+  };
+
+  enum { NORMAL, ESC, CSI, P2, TITLE_PRE, TITLE, TITLE_END } esc_st;
+  int esc_param[2];
+
+  int16_t attr;
+
 protected:
+  vt_action handle_escape_code(int c);
+  vt_action csi_common(int c, int i);
 };


### PR DESCRIPTION
The following are handled:
```
ESC [ K               ; clear to end of line
ESC [ 2 J             ; clear screen
ESC [ count D         ; cursor backwards (default = 1)
x08                   ; cursor backwards 1 (ctrl-H)
ESC [ row ; column H  ; position cursor
ESC [ attr m          ; 0 = normal, 1 = inverse
ESC ] ; ... x1B x5c   ; sets title (ignored)
x07                   ; bell (flashes screen) (ctrl-G)
```

"ESC[ m" is used by RunCPM to set some characters to bold, implemented here as reverse video. The rest are the ones implemented in CircuitPython terminalio and so probably represent a minimal useful collection of codes.

Bell is used by RunCPM for instance when backspacing on an empty input line. The flash is similar to the visual bell used in some terminal applications.

The 1bit_text demo is enhanced so that as soon as a character is printed to the Serial connection, it switches to typewriter mode. This can be used to test escape code handling.