### PR TITLE
made DVIGFX::color565() static

### DIFF
--- a/src/PicoDVI.h
+++ b/src/PicoDVI.h
@@ -118,7 +118,7 @@ public:
     @param   blue   Blue component, 0-255.
     @return  Nearest 16-bit RGB565 equivalent.
   */
-  uint16_t color565(uint8_t red, uint8_t green, uint8_t blue) {
+  static uint16_t color565(uint8_t red, uint8_t green, uint8_t blue) {
     return ((red & 0xF8) << 8) | ((green & 0xFC) << 3) | (blue >> 3);
   }
   /*!


### PR DESCRIPTION
The change allows to use DVIGFX16::color565() without the need of having access to a specific DVIGFX16 object.

It comes in handy when
* the DVIGFX16 object isn't accessible, but a color parameter is required
* the object containing the DVIGFX16 object has a long name or is deeply nested

There is no risk as the function only combines and returns the given arguments.

Best regards,
Sven