### PR TITLE
update for philhower 4.6

### DIFF
--- a/src/libdvi/dvi_config_defs.h
+++ b/src/libdvi/dvi_config_defs.h
@@ -8,8 +8,11 @@
 
 // Pull in base headers to make sure board definitions override the
 // definitions provided here. Note this file is included in asm and C.
+// added ifndef after Philhower 4.6.0 release to fix compilation issue
+#ifndef __ASSEMBLER__
 #include "hardware/platform_defs.h"
 #include "pico/config.h"
+#endif
 
 // ----------------------------------------------------------------------------
 // General DVI defines


### PR DESCRIPTION
This fixes a compilation issue with the updated GCC in the newest release of BSP (4.6). Initially found on the [Learn repo](https://github.com/adafruit/Adafruit_Learning_System_Guides/issues/3066) and reproduced locally.

tested fix locally with hardware for all 3 affected Learn projects (YBox, video synth and DVI PiCowbell demo). 